### PR TITLE
Adding GitPython for ssh key control

### DIFF
--- a/ansible_shed.ini
+++ b/ansible_shed.ini
@@ -11,6 +11,7 @@ port=12345
 repo_path=/tmp/ansible_shed/repo
 # Repo Clone URL
 repo_url=git@github.com:cooperlees/clc_ansible.git
+repo_key=/home/cooper/.ssh/id_rsa
 
 # Ansible base CLI args
 # Paths can be relative from root of your ansible repo

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         "Development Status :: 3 - Alpha",
     ],
     entry_points={"console_scripts": ["ansible-shed = ansible_shed.main:main"]},
-    install_requires=["aioprometheus[aiohttp]", "click"],
+    install_requires=["aioprometheus[aiohttp]", "click", "GitPython"],
     extras_require={
         # If you'd like the ansible toolset dependency installed
         "ansible": ["ansible"],


### PR DESCRIPTION
Migration to git modules for python gives more control for the
configuration of git pull and other commands. In this example
it was private keys.