### PR TITLE
Fixing GitPython which was still incorrectly reading keys

### DIFF
--- a/ansible_shed/shed.py
+++ b/ansible_shed/shed.py
@@ -3,7 +3,7 @@
 import asyncio
 from collections import defaultdict
 from configparser import ConfigParser
-from git import Git, Repo
+from git import Repo
 from json import dumps
 import logging
 from pathlib import Path

--- a/ansible_shed/shed.py
+++ b/ansible_shed/shed.py
@@ -74,7 +74,7 @@ class Shed:
         Repo.clone_from(
             self.repo_url,
             self.repo_path,
-            env={"GIT_SSH_COMMAND": git_ssh_command},
+            env={"GIT_SSH_COMMAND": git_ssh_cmd},
             branch="master",
         )
 


### PR DESCRIPTION
The key file was incidentally working in testing. This addresses
the misreading of keys.

Documentation of how to do this is sparse so that is why it was done incorrectly. By sheer luck, it is using my user shell which also has a key which is useful for the repository which is why this worked previously. In Cooper's setup, this also happened to be the case by chance.