### PR TITLE
make the bind address configurable

### DIFF
--- a/ansible_shed/shed.py
+++ b/ansible_shed/shed.py
@@ -231,7 +231,7 @@ class Shed:
     async def prometheus_server(self) -> None:
         """Use aioprometheus to server statistics to prometheus"""
         self.prom_service = Service()
-        await self.prom_service.start(addr=self.config[SHED_CONFIG_SECTION].get("prometheus_bind_addr") or "::", port=self.stats_port)
+        await self.prom_service.start(addr=self.config[SHED_CONFIG_SECTION].get("prometheus_bind_addr", "::"), port=self.stats_port)
         LOG.info(f"Serving prometheus metrics on: {self.prom_service.metrics_url}")
         await self._update_prom_stats()
 

--- a/ansible_shed/shed.py
+++ b/ansible_shed/shed.py
@@ -231,7 +231,7 @@ class Shed:
     async def prometheus_server(self) -> None:
         """Use aioprometheus to server statistics to prometheus"""
         self.prom_service = Service()
-        await self.prom_service.start(addr="::", port=self.stats_port)
+        await self.prom_service.start(addr=self.config[SHED_CONFIG_SECTION].get("prometheus_bind_addr") or "::", port=self.stats_port)
         LOG.info(f"Serving prometheus metrics on: {self.prom_service.metrics_url}")
         await self._update_prom_stats()
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ ptr_params = {
 
 setup(
     name="ansible_shed",
-    version="2021.4.15",
+    version="2022.1.5",
     description=(
         "asyncio ansible tower like shed to run playbooks and have prometheus "
         + "collector stats"


### PR DESCRIPTION
Currently the bind address is hardcoded but this has been problematic for me as I have hosts with multiple addresses and not all should expose this. Please note that I haven't got a good way to test this, I've seen a bunch of test fixtures but not a sample of one I can test with. I'll run locally from my repo, but thought it pertinent that I inform you.