### PR TITLE
Capture ansible stderr so warning/deprecation counts are recorded

### DIFF
--- a/ansible_shed/shed.py
+++ b/ansible_shed/shed.py
@@ -14,7 +14,7 @@ from datetime import datetime, timezone
 from json import dumps, JSONDecodeError, loads
 from pathlib import Path
 from random import randint
-from subprocess import PIPE, Popen, run
+from subprocess import PIPE, STDOUT, Popen, run
 from time import time
 from typing import TypedDict
 
@@ -410,7 +410,9 @@ class Shed:
         ansible_start_time = time()
 
         if not run_log_path:
-            cp = run(cmd, stdout=PIPE, cwd=self.repo_path, encoding="utf-8")
+            cp = run(
+                cmd, stdout=PIPE, stderr=STDOUT, cwd=self.repo_path, encoding="utf-8"
+            )
             ansible_output = cp.stdout
             return_code = cp.returncode
         else:
@@ -428,7 +430,9 @@ class Shed:
                         lf.write(output_line)
 
                 if p.stderr:
-                    lf.write(p.stderr.read())
+                    stderr_output = p.stderr.read()
+                    ansible_output += stderr_output
+                    lf.write(stderr_output)
 
             return_code = p.returncode
 

--- a/ansible_shed/shed.py
+++ b/ansible_shed/shed.py
@@ -14,7 +14,7 @@ from datetime import datetime, timezone
 from json import dumps, JSONDecodeError, loads
 from pathlib import Path
 from random import randint
-from subprocess import PIPE, STDOUT, Popen, run
+from subprocess import PIPE, Popen, run, STDOUT
 from time import time
 from typing import TypedDict
 

--- a/ansible_shed/tests/ansible_output.py
+++ b/ansible_shed/tests/ansible_output.py
@@ -197,6 +197,4 @@ class RunAnsibleStderrTests(unittest.TestCase):
         # The parser counts those stderr-sourced lines.
         self.shed.parse_ansible_stats(ansible_output, 0)
         self.assertEqual(self.shed.prom_stats["ansible_warnings_count"], 1)
-        self.assertEqual(
-            self.shed.prom_stats["ansible_deprecation_warnings_count"], 1
-        )
+        self.assertEqual(self.shed.prom_stats["ansible_deprecation_warnings_count"], 1)

--- a/ansible_shed/tests/ansible_output.py
+++ b/ansible_shed/tests/ansible_output.py
@@ -2,6 +2,7 @@
 
 import unittest
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from unittest.mock import Mock, patch
 
 from ansible_shed.shed import Shed
@@ -147,3 +148,55 @@ class AnsibleProfileTests(unittest.TestCase):
     def test_top_n_config_default(self) -> None:
         # ansible_shed.ini does not set profile_tasks_top_n; default is 20.
         self.assertEqual(self.shed.profile_tasks_top_n, 20)
+
+
+class RunAnsibleStderrTests(unittest.TestCase):
+    """Ansible emits [WARNING]/[DEPRECATION WARNING] lines on stderr, so
+    _run_ansible must fold stderr into the returned output for the parser to
+    count them."""
+
+    @patch("pathlib.Path.mkdir")
+    def setUp(self, mock_mkdir: Mock) -> None:
+        self.shed = Shed(SHED_CONFIG_PATH)
+        return super().setUp()
+
+    @patch("ansible_shed.shed.Popen")
+    def test_run_ansible_captures_stderr_warnings(self, mock_popen: Mock) -> None:
+        stdout_lines = [
+            "TASK [Gathering Facts] ****\n",
+            "ok: [host1.example.com]\n",
+        ]
+        stderr_text = (
+            "[WARNING]: kubernetes is not supported.\n"
+            "[DEPRECATION WARNING]: apt_repository has been deprecated.\n"
+        )
+
+        proc = Mock()
+        proc.stdout = iter(stdout_lines)
+        proc.stderr = Mock()
+        proc.stderr.read.return_value = stderr_text
+        proc.returncode = 0
+        mock_popen.return_value.__enter__ = Mock(return_value=proc)
+        mock_popen.return_value.__exit__ = Mock(return_value=False)
+
+        with TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "run.log"
+            with (
+                patch.object(self.shed, "_create_logfile", return_value=log_path),
+                patch.object(self.shed, "_update_latest_log_symlink"),
+            ):
+                _, ansible_output = self.shed._run_ansible()
+            log_contents = log_path.read_text()
+
+        # stderr content is folded into the parsed output...
+        self.assertIn("[DEPRECATION WARNING]", ansible_output)
+        self.assertIn("[WARNING]", ansible_output)
+        # ...and is still written to the run log file.
+        self.assertIn("[DEPRECATION WARNING]", log_contents)
+
+        # The parser counts those stderr-sourced lines.
+        self.shed.parse_ansible_stats(ansible_output, 0)
+        self.assertEqual(self.shed.prom_stats["ansible_warnings_count"], 1)
+        self.assertEqual(
+            self.shed.prom_stats["ansible_deprecation_warnings_count"], 1
+        )


### PR DESCRIPTION
## Problem

`ansible_shed` was reporting `ansible_deprecation_warnings_count` (and `ansible_warnings_count`) as `0` to Prometheus even when a run produced deprecation warnings — e.g. the four `apt_repository` deprecations visible in the latest run log.

## Root cause

Ansible emits `[WARNING]` and `[DEPRECATION WARNING]` summary lines on **stderr**, not stdout. The counting logic was correct, but `_run_ansible` only folded **stdout** into the `ansible_output` string handed to the parser:

- **Log path**: stderr was written to the log file (which is why the warnings *appear* in `latest.log`) but never appended to `ansible_output`, so the parser never saw them.
- **Non-log path**: `run()` only captured stdout, dropping stderr entirely.

The log file got both streams while the metrics parser only got stdout — hence warnings visible in the log but missing from the metrics.

## Fix

- Log path: read stderr into `ansible_output` as well as the log file.
- Non-log path: redirect `stderr=STDOUT` so it's captured.

## Test

Added `RunAnsibleStderrTests.test_run_ansible_captures_stderr_warnings`, which mocks `Popen` with the warnings on stderr and asserts they reach both the parsed output and the log file, and that the gauges come out as `1`/`1`. Verified it **fails** without the fix and **passes** with it. Full suite: 71 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)