### PR TITLE
Build aarch64 mypyc wheels alongside x86_64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,25 +33,32 @@ jobs:
             dist/*.whl
 
   wheels:
-    name: Build mypyc wheels (${{ matrix.python }})
-    runs-on: ubuntu-latest
+    name: Build mypyc wheels (${{ matrix.python }}-${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
     strategy:
+      fail-fast: false
       matrix:
         python: ["cp313", "cp314"]
+        arch: [x86_64, aarch64]
+        include:
+          - arch: x86_64
+            runner: ubuntu-latest
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v4.0.0
         env:
-          CIBW_BUILD: ${{ matrix.python }}-manylinux_x86_64
+          CIBW_BUILD: ${{ matrix.python }}-manylinux_${{ matrix.arch }}
           CIBW_ENVIRONMENT: MYPYC_BUILD=1
           CIBW_BUILD_VERBOSITY: 1
 
       - name: Upload wheels
         uses: actions/upload-artifact@v7
         with:
-          name: dist-wheels-${{ matrix.python }}
+          name: dist-wheels-${{ matrix.python }}-${{ matrix.arch }}
           path: wheelhouse/*.whl
 
   publish:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,12 +38,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["cp313", "cp314"]
-        arch: [x86_64, aarch64]
         include:
-          - arch: x86_64
+          - python: cp313
+            arch: x86_64
             runner: ubuntu-latest
-          - arch: aarch64
+          - python: cp313
+            arch: aarch64
+            runner: ubuntu-24.04-arm
+          - python: cp314
+            arch: x86_64
+            runner: ubuntu-latest
+          - python: cp314
+            arch: aarch64
             runner: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Add an arch axis to the release wheels matrix so cibuildwheel produces manylinux_aarch64 wheels in addition to x86_64, for both cp313 and cp314. aarch64 builds run on GitHub's native ubuntu-24.04-arm runners to avoid slow QEMU emulation of mypyc compilation. Artifacts are named per-arch and still match the publish job's dist-* download pattern, so all wheels upload to PyPI on release.