### PR TITLE
Fix leaked git cat-file subprocess wedging ansible_runner()

### DIFF
--- a/ansible_shed/shed.py
+++ b/ansible_shed/shed.py
@@ -301,10 +301,17 @@ class Shed:
         git_ssh_cmd = f"ssh -i {self.config[SHED_CONFIG_SECTION].get('repo_key')}"
         if self.init_file.exists():
             LOG.info(f"Rebasing {self.repo_path} from {self.repo_url}")
-            repo = Repo(self.repo_path)
-            with repo.git.custom_environment(GIT_SSH_COMMAND=git_ssh_cmd):
-                repo.remotes.origin.fetch()
-                repo.remotes.origin.refs.main.checkout()
+            # Repo must be closed (context manager) or it leaks a persistent
+            # `git cat-file --batch-check` helper subprocess per call. A
+            # fresh Repo(...) is created every run_interval_seconds here, so
+            # an unclosed one accumulates one leaked process per cycle
+            # forever - eventually enough of them pile up (holding the repo
+            # open) that a later fetch/checkout hangs indefinitely, wedging
+            # this whole coroutine with no exception and no crash.
+            with Repo(self.repo_path) as repo:
+                with repo.git.custom_environment(GIT_SSH_COMMAND=git_ssh_cmd):
+                    repo.remotes.origin.fetch()
+                    repo.remotes.origin.refs.main.checkout()
             self._setup_vault_pass()
             return
 
@@ -318,12 +325,13 @@ class Shed:
         self.repo_path.mkdir(parents=True)
         LOG.info(f"Cloning {self.repo_url} to {self.repo_path}")
 
-        Repo.clone_from(
+        with Repo.clone_from(
             self.repo_url,
             self.repo_path,
             env={"GIT_SSH_COMMAND": git_ssh_cmd},
             branch="main",
-        )
+        ):
+            pass
 
         self._setup_vault_pass()
 

--- a/ansible_shed/tests/base.py
+++ b/ansible_shed/tests/base.py
@@ -12,6 +12,7 @@ from ansible_shed.tests.ansible_output import (  # noqa: F401
 from ansible_shed.tests.api import APITests  # noqa: F401
 from ansible_shed.tests.client_cli import ClientConfigAndCLITests  # noqa: F401
 from ansible_shed.tests.client_http import ClientHttpTests  # noqa: F401
+from ansible_shed.tests.rebase_or_clone_repo import RebaseOrCloneRepoTests  # noqa: F401
 from ansible_shed.tests.version_check_state import VersionCheckStateTests  # noqa: F401
 
 

--- a/ansible_shed/tests/rebase_or_clone_repo.py
+++ b/ansible_shed/tests/rebase_or_clone_repo.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from ansible_shed.shed import Shed
+
+
+class RebaseOrCloneRepoTests(unittest.TestCase):
+    """Regression tests for the leaked `git cat-file --batch-check` bug.
+
+    `Repo(...)` must always be used as a context manager (or otherwise
+    explicitly `.close()`-d): GitPython lazily starts a persistent
+    `git cat-file --batch-check` helper process per `Repo` instance and never
+    tears it down on its own. `_rebase_or_clone_repo` builds a fresh `Repo`
+    every run_interval_seconds forever, so an unclosed one leaks one such
+    process per cycle - enough of these accumulating eventually wedges a
+    later fetch/checkout indefinitely, with no exception and no crash.
+    """
+
+    def setUp(self) -> None:
+        self.test_dir = tempfile.TemporaryDirectory()
+        self.test_path = Path(self.test_dir.name)
+        self.repo_path = self.test_path / "repo"
+        self.config_file = self.test_path / "test_config.ini"
+        self.config_file.write_text(f"""[ansible_shed]
+interval=60
+port=12345
+repo_path={self.repo_path}
+repo_url=git@github.com:test/test.git
+repo_key={self.test_path / "key"}
+ansible_hosts_inventory=hosts
+ansible_playbook_init=site.yaml
+""")
+
+    def tearDown(self) -> None:
+        self.test_dir.cleanup()
+
+    @patch("ansible_shed.shed.Repo")
+    def test_fetch_and_checkout_path_closes_repo(
+        self, mock_repo_cls: MagicMock
+    ) -> None:
+        self.repo_path.mkdir(parents=True)
+        (self.repo_path / "site.yaml").write_text("---")
+        shed = Shed(self.config_file)
+
+        mock_repo = mock_repo_cls.return_value
+        mock_repo.__enter__.return_value = mock_repo
+
+        shed._rebase_or_clone_repo()
+
+        mock_repo_cls.assert_called_once_with(self.repo_path)
+        mock_repo.__enter__.assert_called_once()
+        mock_repo.__exit__.assert_called_once()
+        mock_repo.remotes.origin.fetch.assert_called_once()
+        mock_repo.remotes.origin.refs.main.checkout.assert_called_once()
+
+    @patch("ansible_shed.shed.Repo")
+    def test_clone_path_closes_repo(self, mock_repo_cls: MagicMock) -> None:
+        # repo_path doesn't exist and site.yaml (init_file) doesn't either,
+        # so this takes the clone_from(...) branch instead.
+        shed = Shed(self.config_file)
+
+        mock_repo = mock_repo_cls.clone_from.return_value
+        mock_repo.__enter__.return_value = mock_repo
+
+        shed._rebase_or_clone_repo()
+
+        mock_repo_cls.clone_from.assert_called_once()
+        mock_repo.__enter__.assert_called_once()
+        mock_repo.__exit__.assert_called_once()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary

Found while debugging a production `ansible_shed` instance (on `home1`) that
had been silently stuck since ~03:06 that morning — its git checkout hadn't
advanced through several new commits, while its Prometheus `/metrics`
endpoint kept responding normally the whole time. That combination (dead
automation loop, healthy HTTP server) is the tell: `prometheus_server()` and
`ansible_runner()` run as two independent coroutines under one
`asyncio.gather()`, so a hang in one doesn't crash or even affect the other.

Root cause: `_rebase_or_clone_repo()` builds a fresh `git.Repo(self.repo_path)`
every `run_interval_seconds` and never closes it. GitPython lazily starts a
persistent `git cat-file --batch-check` helper subprocess per `Repo` instance
for object access, and never tears it down on its own — `Repo.close()` (or
using it as a context manager) is required. Confirmed on the stuck host:
three orphaned `git cat-file --batch-check` processes, each just sitting in
`S` (sleeping) state reading from a pipe that will never get more input or
be closed, spaced ~4h apart. Enough of these piling up eventually wedges a
later `fetch()`/`checkout()` indefinitely — no exception, no crash, just a
permanently stuck coroutine.

## Fix

Use `Repo(...)` / `Repo.clone_from(...)` as a context manager in both
branches of `_rebase_or_clone_repo`, so each one's internal subprocess is
torn down when the function returns.

## Test plan

- [x] New `RebaseOrCloneRepoTests` (fetch+checkout path and clone path) assert
      `Repo(...)`'s context manager `__exit__`/`close()` gets invoked
- [x] Full suite: `python -m unittest ansible_shed.tests.base` — 35 passed
- [x] `mypy --strict ansible_shed` — clean
- [x] `black --check` / `usort check` / `flake8` — clean
- [ ] Deploy to `home1` and confirm no more leaked `git cat-file` processes
      accumulate over the following few cycles (can watch with
      `ps --forest -g $(ps -o sid= -p <ansible-shed pid>)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T7xG9yu6xToe8ZGiraFMYe